### PR TITLE
Attempt to fix gemspec problem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,2 @@
 source 'https://rubygems.org'
 gemspec
-
-# Required for Travis CI
-gem 'rake', '>=10.0.0'

--- a/supply_drop.gemspec
+++ b/supply_drop.gemspec
@@ -1,5 +1,3 @@
-require 'rake'
-
 Gem::Specification.new do |s|
   s.name = "supply_drop"
   s.summary = "Masterless puppet with capistrano"
@@ -9,6 +7,7 @@ Gem::Specification.new do |s|
   s.email = ["tony.pitluga@gmail.com", "paul.t.hinze@gmail.com"]
   s.homepage = "http://github.com/pitluga/supply_drop"
   s.license = "MIT"
-  s.files = FileList["README.md", "Rakefile", "lib/**/*.rb"]
+  s.files = ['README.md', 'Rakefile'] + Dir['lib/**/*.rb']
   s.add_dependency('capistrano', '>= 3.0.1', '< 4.0.0')
+  s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Original PR by Eric: https://github.com/pitluga/supply_drop/pull/67
## 

When my application runs on CircleCI I occasionally get an error that looks like the following:

```
There was a LoadError while loading supply_drop.gemspec: 
cannot load such file -- rake from
/home/ubuntu/supply_drop_test/vendor/bundle/ruby/2.3.0/bundler/gems/supply_drop-d64c50c1e658/supply_drop.gemspec:1:in
`<main>'
```

The usage of Rake in a gemspec is not unusual. In fact the rubygem spec even recommends it as an option. The error doesn't make much sense as obviously rake should be found since is included with Ruby. This issue seemed to come about when I upgraded to a newer version of Ruby (2.3.1).

What I think is happening is that CircleCI is installing the right version of Ruby and gems requested but that the bundle check it is doing is still running under the version of Ruby that was previously there from the cache or if no cache then their default version of Ruby. I think there an incompatibility between the slightly older version of ruby and the newer version of the rake library causing it to fail to load.

In an attempt to confirm all this I created a demo repo that tries to be the simplest repeatable setup I could. If I made it use an older ruby (2.5.1) I never get the issue (I think because the rake with that version is compatible with the default ruby binary on CircleCI), but when I use 2.3.0 or 2.3.1 I can consistently get the issue anytime I re-build without the cache. In my application I also sometimes get it even with the cache as the test starts to execute although I couldn't duplicate that in my demo repo.

This all may be fundamentally a CircleCI issue (I'm going to refer this ticket to them so they can investigate on their end if they wish) but to make supply_drop not susceptible to this issue I am creating a commit that removes the rake dependency completely and instead just relies on simpler built-in primitives (namely Dir[]).
